### PR TITLE
convert unstructured.Unstructured to corev1.Namespace before applying

### DIFF
--- a/pkg/controller/nstemplateset/nstemplateset_controller.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller.go
@@ -175,8 +175,8 @@ func (r *ReconcileNSTemplateSet) ensureNamespaceResource(logger logr.Logger, nsT
 			"failed to process template for namespace type '%s'", tcNamespace.Type)
 	}
 
-	for _, rawObj := range objs {
-		acc, err := meta.Accessor(rawObj.Object)
+	for i, obj := range objs {
+		acc, err := meta.Accessor(obj)
 		if err != nil {
 			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err,
 				"invalid element in template for namespace type '%s'", tcNamespace.Type)
@@ -196,6 +196,11 @@ func (r *ReconcileNSTemplateSet) ensureNamespaceResource(logger logr.Logger, nsT
 			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err,
 				"failed to set controller reference for namespace type '%s'", tcNamespace.Type)
 		}
+		ns := &corev1.Namespace{}
+		if err := r.scheme.Convert(obj, ns, nil); err != nil {
+			return err
+		}
+		objs[i] = ns
 	}
 
 	err = tmplProcessor.Apply(objs)

--- a/pkg/controller/nstemplateset/nstemplateset_controller_test.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller_test.go
@@ -110,7 +110,7 @@ func TestReconcileProvisionOK(t *testing.T) {
 		assert.Equal(t, reconcile.Result{}, res)
 	}
 
-	t.Run("ok", func(t *testing.T) {
+	t.Run("ok with 2 namespaces", func(t *testing.T) {
 		r, req, fakeClient := prepareReconcile(t, username, nsTmplSet)
 
 		// for dev
@@ -264,20 +264,20 @@ func checkNamespace(t *testing.T, cl client.Client, username, typeName string) *
 	// code - if err := meta.SetList(list, matchingObjs); err != nil {
 	// file - k8s.io/client-go/testing/fixture.go, line - 239
 
-	// labels := map[string]string{"owner": username, "type": typeName}
-	// opts := client.MatchingLabels(labels)
-	// namespaceList := &corev1.NamespaceList{}
-	// err := cl.List(context.TODO(), opts, namespaceList)
-	// require.NoError(t, err)
-	// require.NotNil(t, namespaceList)
-	// require.Equal(t, 1, len(namespaceList.Items))
-	// return &namespaceList.Items[0]
-
-	namespace := &corev1.Namespace{}
-	nsName := fmt.Sprintf("%s-%s", username, typeName)
-	err := cl.Get(context.TODO(), types.NamespacedName{Name: nsName}, namespace)
+	labels := map[string]string{"owner": username, "type": typeName}
+	opts := client.MatchingLabels(labels)
+	namespaceList := &corev1.NamespaceList{}
+	err := cl.List(context.TODO(), opts, namespaceList)
 	require.NoError(t, err)
-	return namespace
+	require.NotNil(t, namespaceList)
+	require.Equal(t, 1, len(namespaceList.Items))
+	return &namespaceList.Items[0]
+
+	// namespace := &corev1.Namespace{}
+	// nsName := fmt.Sprintf("%s-%s", username, typeName)
+	// err := cl.Get(context.TODO(), types.NamespacedName{Name: nsName}, namespace)
+	// require.NoError(t, err)
+	// return namespace
 }
 
 func checkChildren(t *testing.T, client *test.FakeClient, nsName string) {

--- a/pkg/controller/nstemplateset/nstemplateset_util.go
+++ b/pkg/controller/nstemplateset/nstemplateset_util.go
@@ -10,31 +10,31 @@ metadata:
     project: codeready-toolchain
   name: basic-dev
 objects:
-  - apiVersion: v1
-    kind: Namespace
-    metadata:
-      labels:
-        provider: codeready-toolchain
-        project: codeready-toolchain
-      name: ${USER_NAME}-dev
-  - apiVersion: authorization.openshift.io/v1
-    kind: RoleBinding
-    metadata:
-      labels:
-        provider: codeready-toolchain
-        app: codeready-toolchain
-      name: user-edit
-      namespace: ${USER_NAME}-dev
-    roleRef:
-      name: edit
-    subjects:
-      - kind: User
-        name: ${USER_NAME}
-    userNames:
-      - ${USER_NAME}
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    labels:
+      provider: codeready-toolchain
+      project: codeready-toolchain
+    name: ${USER_NAME}-dev
+- apiVersion: authorization.openshift.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      provider: codeready-toolchain
+      app: codeready-toolchain
+    name: user-edit
+    namespace: ${USER_NAME}-dev
+  roleRef:
+    name: edit
+  subjects:
+    - kind: User
+      name: ${USER_NAME}
+  userNames:
+    - ${USER_NAME}
 parameters:
-  - name: USER_NAME
-    value: johnsmith
+- name: USER_NAME
+  value: johnsmith
 `)
 
 var _templatesBasicCodeYaml = []byte(`apiVersion: template.openshift.io/v1
@@ -45,31 +45,31 @@ metadata:
     project: codeready-toolchain
   name: basic-code
 objects:
-  - apiVersion: v1
-    kind: Namespace
-    metadata:
-      labels:
-        provider: codeready-toolchain
-        project: codeready-toolchain
-      name: ${USER_NAME}-code
-  - apiVersion: authorization.openshift.io/v1
-    kind: RoleBinding
-    metadata:
-      labels:
-        provider: codeready-toolchain
-        app: codeready-toolchain
-      name: user-edit
-      namespace: ${USER_NAME}-code
-    roleRef:
-      name: edit
-    subjects:
-      - kind: User
-        name: ${USER_NAME}
-    userNames:
-      - ${USER_NAME}
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    labels:
+      provider: codeready-toolchain
+      project: codeready-toolchain
+    name: ${USER_NAME}-code
+- apiVersion: authorization.openshift.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      provider: codeready-toolchain
+      app: codeready-toolchain
+    name: user-edit
+    namespace: ${USER_NAME}-code
+  roleRef:
+    name: edit
+  subjects:
+    - kind: User
+      name: ${USER_NAME}
+  userNames:
+    - ${USER_NAME}
 parameters:
-  - name: USER_NAME
-    value: johnsmith
+- name: USER_NAME
+  value: johnsmith
 `)
 
 var _templatesBasicStageYaml = []byte(`apiVersion: template.openshift.io/v1
@@ -80,31 +80,31 @@ metadata:
     project: codeready-toolchain
   name: basic-stage
 objects:
-  - apiVersion: v1
-    kind: Namespace
-    metadata:
-      labels:
-        provider: codeready-toolchain
-        project: codeready-toolchain
-      name: ${USER_NAME}-stage
-  - apiVersion: authorization.openshift.io/v1
-    kind: RoleBinding
-    metadata:
-      labels:
-        provider: codeready-toolchain
-        app: codeready-toolchain
-      name: user-edit
-      namespace: ${USER_NAME}-stage
-    roleRef:
-      name: edit
-    subjects:
-      - kind: User
-        name: ${USER_NAME}
-    userNames:
-      - ${USER_NAME}
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    labels:
+      provider: codeready-toolchain
+      project: codeready-toolchain
+    name: ${USER_NAME}-stage
+- apiVersion: authorization.openshift.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      provider: codeready-toolchain
+      app: codeready-toolchain
+    name: user-edit
+    namespace: ${USER_NAME}-stage
+  roleRef:
+    name: edit
+  subjects:
+    - kind: User
+      name: ${USER_NAME}
+  userNames:
+    - ${USER_NAME}
 parameters:
-  - name: USER_NAME
-    value: johnsmith
+- name: USER_NAME
+  value: johnsmith
 `)
 
 func getTemplateContent(tierName, typeName string) ([]byte, error) {

--- a/pkg/template/filter.go
+++ b/pkg/template/filter.go
@@ -4,24 +4,24 @@ import "k8s.io/apimachinery/pkg/runtime"
 
 var (
 	// RetainNamespaces a func to retain only namespaces
-	RetainNamespaces FilterFunc = func(obj runtime.RawExtension) bool {
-		gvk := obj.Object.GetObjectKind().GroupVersionKind()
+	RetainNamespaces FilterFunc = func(obj runtime.Object) bool {
+		gvk := obj.GetObjectKind().GroupVersionKind()
 		return gvk.Kind == "Namespace"
 	}
 
 	// RetainAllButNamespaces a func to retain all but namespaces
-	RetainAllButNamespaces FilterFunc = func(obj runtime.RawExtension) bool {
-		gvk := obj.Object.GetObjectKind().GroupVersionKind()
+	RetainAllButNamespaces FilterFunc = func(obj runtime.Object) bool {
+		gvk := obj.GetObjectKind().GroupVersionKind()
 		return gvk.Kind != "Namespace"
 	}
 )
 
 // FilterFunc a function to retain an object or not
-type FilterFunc func(runtime.RawExtension) bool
+type FilterFunc func(runtime.Object) bool
 
 // Filter filters the given objs to return only those matching the given filters (if any)
-func Filter(objs []runtime.RawExtension, filters ...FilterFunc) []runtime.RawExtension {
-	result := make([]runtime.RawExtension, 0, len(objs))
+func Filter(objs []runtime.Object, filters ...FilterFunc) []runtime.Object {
+	result := make([]runtime.Object, 0, len(objs))
 loop:
 	for _, obj := range objs {
 		for _, filter := range filters {

--- a/pkg/template/processor.go
+++ b/pkg/template/processor.go
@@ -30,7 +30,7 @@ func NewProcessor(cl client.Client, scheme *runtime.Scheme) Processor {
 
 // Process processes the template (ie, replaces the variables with their actual values) and optionally filters the result
 // to return a subset of the template objects
-func (p Processor) Process(tmplContent []byte, values map[string]string, filters ...FilterFunc) ([]runtime.RawExtension, error) {
+func (p Processor) Process(tmplContent []byte, values map[string]string, filters ...FilterFunc) ([]runtime.Object, error) {
 	obj, _, err := p.codecFactory.UniversalDeserializer().Decode(tmplContent, nil, nil)
 	if err != nil {
 		return nil, errs.Wrapf(err, "unable to decode template")
@@ -58,13 +58,16 @@ func (p Processor) Process(tmplContent []byte, values map[string]string, filters
 	if err := p.scheme.Convert(tmpl, &result, nil); err != nil {
 		return nil, errs.Wrap(err, "failed to convert template to external template object")
 	}
-	return Filter(result.Objects, filters...), nil
+	objects := make([]runtime.Object, len(result.Objects))
+	for i := range result.Objects {
+		objects[i] = result.Objects[i].Object
+	}
+	return Filter(objects, filters...), nil
 }
 
 // Apply applies the objects, ie, creates or updates them on the cluster
-func (p Processor) Apply(objs []runtime.RawExtension) error {
-	for _, rawObj := range objs {
-		obj := rawObj.Object
+func (p Processor) Apply(objs []runtime.Object) error {
+	for _, obj := range objs {
 		if obj == nil {
 			continue
 		}


### PR DESCRIPTION
also, refactor Processor API to manage `runtime.Object` elements

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>